### PR TITLE
Small changes to enable running on windows

### DIFF
--- a/pagi/scripts/cli.py
+++ b/pagi/scripts/cli.py
@@ -31,6 +31,9 @@ from pagi.utils import logger_utils
 from pagi.utils import generic_utils as util
 from pagi.utils.tb_debug import TbDebug
 
+# constants for handling exit code for windows (not covered by os module)
+PAGI_CLI_WINDOWS_OS_NAME ='nt'
+PAGI_CLI_WINDOWS_EX_OK = 0
 
 @click.group()
 @click.version_option()
@@ -120,6 +123,10 @@ def run(dataset, workflow, component, dataset_location, hparams_override, hparam
       _run_experiment(flags, exp_config)
   else:
     _run_experiment(flags, exp_config)
+
+  # EX_OK not defined for windows
+  if os.name == PAGI_CLI_WINDOWS_OS_NAME:
+    os._exit(PAGI_CLI_WINDOWS_EX_OK)
 
   os._exit(os.EX_OK)  # pylint: disable=protected-access
 

--- a/pagi/utils/image_utils.py
+++ b/pagi/utils/image_utils.py
@@ -91,7 +91,7 @@ def degrade_image_shape(image, label=None,
   ys = tf.random_uniform(shape=[batch_size, 1], minval=r, maxval=height-r, dtype=tf.int64)
 
   int_image = tf.range(0, image_size)
-  col = int_image % width  # same shape as image tensor, but values are the col idx
+  col = tf.to_int64(int_image % width)  # same shape as image tensor, but values are the col idx
   row = tf.to_int64(int_image / height)  # same but for row idx
 
   col = tf.expand_dims(col, axis=0)   # add a batch dimension


### PR DESCRIPTION
Math ops require int64 in image_utils.py  (e.g. for line 105)
Exit code EX_OK not available in windows, so a custom value is used instead